### PR TITLE
Improve sidebar UI styles

### DIFF
--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -11,6 +11,15 @@
   color: #333;
 }
 
+/* Utility class to hide native scrollbars */
+.no-scrollbar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 .sidebar {
   position: fixed !important;
   top: 0 !important;
@@ -476,6 +485,7 @@
 .modal-folder-delete-btn {
   background: #ff3b30;
   color: #fff;
+  display: none;
 }
 
 /* Sélection dossiers dans la modal */
@@ -582,4 +592,9 @@
 
 .edit-prompt-button:hover {
   background: rgba(0, 0, 0, 0.1);
+}
+
+/* Hide hidden input used for CSV import */
+.sidebar-import-file-input {
+  display: none;
 }

--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -175,8 +175,6 @@
 .sidebar-section:not(.myExtension-collapsed) .sidebar-prompt-section {
   display: block;
   overflow-y: auto;
-  max-height: 300px;
-  min-height: 50px;
 }
 
 .sidebar-section.myExtension-collapsed .sidebar-folder-section,
@@ -189,6 +187,10 @@
 
 .sidebar-section .sidebar-folder-section {
   transition: max-height 0.3s ease;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
 }
 
 /* Folders list avec scroll si nécessaire */
@@ -220,7 +222,6 @@
   padding: 2px; /* Réduction du padding */
   padding-bottom: 1px; /* Ajout pour éviter que les éléments soient trop près du bord */
   overflow-x: hidden;
-  max-height: 80%;
 }
 
 /* Liste des prompts */

--- a/html/sidebar.html
+++ b/html/sidebar.html
@@ -63,7 +63,7 @@
 </div>
 
 <!-- Modal prompt -->
-<div class="sidebar-modal-backdrop" style="display:none;">
+<div class="sidebar-modal-backdrop">
   <div class="sidebar-modal">
     <h3 class="modal-title">Créer/Editer le prompt</h3>
     <label>Nom : <input type="text" class="modal-prompt-name"></label>
@@ -79,16 +79,16 @@
 </div>
 
 <!-- Modal folder -->
-<div class="sidebar-modal-backdrop-folder" style="display:none;">
+<div class="sidebar-modal-backdrop-folder">
   <div class="sidebar-modal">
     <h3 class="modal-title">Éditer le dossier</h3>
     <label>Nom du dossier : <input type="text" class="modal-folder-name"></label>
     <div class="modal-folder-buttons">
       <button class="modal-folder-save-btn">Enregistrer</button>
       <button class="modal-folder-cancel-btn">Annuler</button>
-      <button class="modal-folder-delete-btn" style="display:none;">Supprimer</button>
+      <button class="modal-folder-delete-btn">Supprimer</button>
     </div>
   </div>
 </div>
 
-<input type="file" class="sidebar-import-file-input" accept=".csv" style="display:none;" />
+<input type="file" class="sidebar-import-file-input" accept=".csv" />

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -75,7 +75,7 @@ function toggleSection(section, toggleButton) {
   if (isCollapsed) {
     section.style.maxHeight = '50px';
   } else {
-    section.style.maxHeight = '300px'; // Taille ouverte par défaut
+    section.style.maxHeight = '';
   }
 }
 
@@ -152,8 +152,10 @@ function initializeSidebarEvents() {
 
         // Empêche les changements de taille en recalculant uniquement le contenu
         const promptsSection = document.querySelector('.sidebar-prompts-section');
-        if (promptsSection && promptsSection.classList.contains('collapsed')) {
+        if (promptsSection && promptsSection.classList.contains('myExtension-collapsed')) {
           promptsSection.style.maxHeight = '50px';
+        } else if (promptsSection) {
+          promptsSection.style.maxHeight = '';
         }
       });
     });
@@ -330,11 +332,7 @@ function adjustSectionHeights() {
   const promptsSection = sidebar.querySelector('.sidebar-prompts-section');
 
   if (folderSection && promptsSection) {
-    const availableHeight = sidebar.offsetHeight;
-
-    // Allouer de l'espace dynamique
-    const foldersHeight = folderSection.offsetHeight;
-    promptsSection.style.maxHeight = `${availableHeight - foldersHeight - 50}px`;
+    promptsSection.style.maxHeight = '';
   }
 }
 

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -70,7 +70,7 @@ function injectSidebarCSS() {
 // Fonction pour basculer une section
 function toggleSection(section, toggleButton) {
   const isCollapsed = section.classList.toggle('myExtension-collapsed');
-  toggleButton.textContent = isCollapsed ? '◄' : '▼';
+  toggleButton.textContent = isCollapsed ? '►' : '▼';
 
   if (isCollapsed) {
     section.style.maxHeight = '50px';


### PR DESCRIPTION
## Summary
- clean up inline style usage in sidebar HTML
- add utility CSS for hiding scrollbars
- hide delete and import elements by default
- update collapse icon to use a right arrow

## Testing
- `npx stylelint "**/*.css"` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_685a9e0a93b883209cdd273828242373