### PR TITLE
Improve prompt card layout

### DIFF
--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -305,6 +305,18 @@
     -webkit-box-orient: vertical;
 }
 
+.sidebar-prompt-preview {
+  font-size: 12px;
+  color: #777;
+  text-align: left;
+  margin: 4px 0;
+  overflow: hidden;
+  display: -webkit-box;
+    -webkit-line-clamp: 2;
+           line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
 .sidebar-prompt-actions {
   display: flex;
   gap: 5px;

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -446,10 +446,12 @@ function refreshPrompts() {
       const nameElement = existingItem.querySelector('.sidebar-prompt-name');
       const tagsElement = existingItem.querySelector('.sidebar-prompt-tags');
       const descriptionElement = existingItem.querySelector('.sidebar-prompt-description');
+      const previewElement = existingItem.querySelector('.sidebar-prompt-preview');
 
       if (nameElement) nameElement.textContent = prompt.name;
       if (tagsElement) tagsElement.innerHTML = tagsHTML;
       if (descriptionElement) descriptionElement.textContent = prompt.description;
+      if (previewElement) previewElement.textContent = textPreview;
     } else {
       const li = document.createElement('li');
       li.className = 'sidebar-prompt-item'; 
@@ -461,6 +463,7 @@ function refreshPrompts() {
         </div>
         <div class="sidebar-prompt-content">
           <p class="sidebar-prompt-description">${prompt.description}</p>
+          <p class="sidebar-prompt-preview">${textPreview}</p>
           ${tagsHTML}
         </div>
         <div class="sidebar-prompt-actions">


### PR DESCRIPTION
## Summary
- show a short preview of the prompt text inside each prompt card
- style the new preview element

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685abf59300483209e0e4b88087003f4